### PR TITLE
Fix get release namespace in helm >=2.10.0

### DIFF
--- a/_modules/helm.py
+++ b/_modules/helm.py
@@ -90,7 +90,7 @@ def _get_release_namespace(name, tiller_namespace="kube-system", **kwargs):
   if not result or len(result.split("\n")) < 2:
     return None
 
-  return result.split("\n")[1].split("\t")[5]
+  return result.split("\n")[1].split("\t")[-1]
 
 def list_repos(**kwargs):
   '''


### PR DESCRIPTION
Starting from 2.10.0 helm added column `APP VERSION` between `CHART` and `NAMESPACE` what cause delete/install loop because script returns app version instead of namespace, but namespace is always as a last column, for all helm versions